### PR TITLE
Fix push notification sound ios

### DIFF
--- a/src/firebase.py
+++ b/src/firebase.py
@@ -294,6 +294,7 @@ def push_notification(
         apns=messaging.APNSConfig(
             payload=messaging.APNSPayload(
                 aps=messaging.Aps(content_available=True),
+                sound="default",
             ),
         ),
     )

--- a/src/firebase.py
+++ b/src/firebase.py
@@ -293,8 +293,7 @@ def push_notification(
         data=data,
         apns=messaging.APNSConfig(
             payload=messaging.APNSPayload(
-                aps=messaging.Aps(content_available=True),
-                sound="default",
+                aps=messaging.Aps(content_available=True, sound="default"),
             ),
         ),
     )


### PR DESCRIPTION
This PR moves the sound property inside the aps parameter to ensure proper configuration of push notifications. The previous implementation was wrong.