### PR TITLE
Remove unused eventlet dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 gunicorn==22.0.0
-eventlet==0.35.2
 gevent-websocket==0.10.1
 Flask==2.3.2
 Authlib==1.3.1


### PR DESCRIPTION
## Summary
Removes the unused `eventlet` dependency from requirements.txt.

## Analysis
Investigation revealed that eventlet is not used anywhere in the codebase:

- ✅ **No code imports**: No `import eventlet` in any Python files
- ✅ **No dependency requirement**: `pip show eventlet` shows no packages require it
- ✅ **Gunicorn uses gthread**: All configurations use `--worker-class=gthread`, not eventlet workers
- ✅ **No SocketIO**: flask_socketio was removed, which was the original reason for eventlet
- ✅ **Firebase for real-time**: Real-time communication uses Firebase, not SocketIO/eventlet

## History
eventlet was added historically when flask_socketio was used for real-time features. After migrating to Firebase for real-time communication, flask_socketio was removed but eventlet was mistakenly left in requirements.txt.

## Benefits
- Reduces dependency footprint
- Reduces security surface area
- Eliminates confusion about unused dependencies
- Allows closing Dependabot PR #124 (eventlet security updates for unused dependency)

## Testing
No testing required - the dependency is not used anywhere in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>