### PR TITLE
Rewrite /stats/ratings: archive-based tables, ~30x faster, no false positives

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ types-google-cloud-ndb
 Flask-Cors==6.0.0
 PyJWT
 google-cloud-secret-manager==2.23.2
+google-cloud-tasks==2.19.3
 Pillow

--- a/src/db/ndb/backend.py
+++ b/src/db/ndb/backend.py
@@ -23,6 +23,7 @@ from .repositories import (
     BlockRepository,
     ZombieRepository,
     RatingRepository,
+    RatingArchiveRepository,
     RiddleRepository,
     ImageRepository,
     ReportRepository,
@@ -45,6 +46,7 @@ if TYPE_CHECKING:
         BlockRepositoryProtocol,
         ZombieRepositoryProtocol,
         RatingRepositoryProtocol,
+        RatingArchiveRepositoryProtocol,
         RiddleRepositoryProtocol,
         ImageRepositoryProtocol,
         ReportRepositoryProtocol,
@@ -118,6 +120,7 @@ class NDBBackend:
         self._blocks = BlockRepository()
         self._zombies = ZombieRepository()
         self._ratings = RatingRepository()
+        self._rating_archive = RatingArchiveRepository()
         self._riddles = RiddleRepository()
         self._images = ImageRepository()
         self._reports = ReportRepository()
@@ -176,6 +179,11 @@ class NDBBackend:
     def ratings(self) -> "RatingRepositoryProtocol":
         """Access the Rating repository."""
         return self._ratings
+
+    @property
+    def rating_archive(self) -> "RatingArchiveRepositoryProtocol":
+        """Access the RatingArchive repository."""
+        return self._rating_archive
 
     @property
     def riddles(self) -> "RiddleRepositoryProtocol":

--- a/src/db/ndb/repositories.py
+++ b/src/db/ndb/repositories.py
@@ -171,6 +171,11 @@ class UserRepository:
         result = skrafldb.UserModel.list_similar_elo(elo, max_len, locale)
         return [(uid, EloDict(e.elo, e.human_elo, e.manual_elo)) for uid, e in result]
 
+    def list_top_elo(self, kind: str, limit: int) -> List[str]:
+        """List the ids of the users with the highest current 'old style'
+        Elo rating of the given kind, in descending order."""
+        return skrafldb.UserModel.list_top_elo(kind, limit)
+
     def query(self) -> "QueryProtocol[UserEntity]":
         """Return a query object for users."""
         # Return a wrapper that converts NDB query results to UserEntity
@@ -384,11 +389,21 @@ class StatsRepository:
         return StatsEntity(model)
 
     def newest_before(
-        self, ts: datetime, user_id: str, robot_level: int = 0
+        self, ts: datetime, user_id: Optional[str], robot_level: int = 0
     ) -> StatsEntity:
-        """Get the most recent stats before a timestamp."""
+        """Get the most recent stats at or before a timestamp.
+        A user_id of None denotes a robot, further identified
+        by its robot_level."""
         model = skrafldb.StatsModel.newest_before(ts, user_id, robot_level)
         return StatsEntity(model)
+
+    def newest_before_multi(
+        self, ts: datetime, keys: Sequence[Tuple[Optional[str], int]]
+    ) -> List[StatsEntity]:
+        """Get the most recent stats at or before a timestamp for multiple
+        (user_id, robot_level) keys at once, in parallel."""
+        models = skrafldb.StatsModel.newest_before_multi(ts, keys)
+        return [StatsEntity(m) for m in models]
 
     def last_for_user(self, user_id: str, days: int) -> List[StatsEntity]:
         """Get stats entries for a user over the last N days."""
@@ -713,6 +728,22 @@ class RatingRepository:
     def delete_all(self) -> None:
         """Delete all rating entries."""
         skrafldb.RatingModel.delete_all()
+
+
+class RatingArchiveRepository:
+    """NDB implementation of RatingArchiveRepositoryProtocol."""
+
+    def put_archive(self, kind: str, key_date: str, table_json: str) -> None:
+        """Store or overwrite the archived table for a kind and ISO date."""
+        skrafldb.RatingArchiveModel.store(kind, key_date, table_json)
+
+    def get_archive(self, kind: str, key_date: str) -> Optional[str]:
+        """Fetch the archived table for a kind and ISO date, or None."""
+        return skrafldb.RatingArchiveModel.fetch_json(kind, key_date)
+
+    def delete_archive(self, kind: str, key_date: str) -> None:
+        """Delete the archived table for a kind and ISO date, if present."""
+        skrafldb.RatingArchiveModel.delete(kind, key_date)
 
 
 class RiddleRepository:

--- a/src/db/postgresql/backend.py
+++ b/src/db/postgresql/backend.py
@@ -25,6 +25,7 @@ from .repositories import (
     BlockRepository,
     ZombieRepository,
     RatingRepository,
+    RatingArchiveRepository,
     RiddleRepository,
     ImageRepository,
     ReportRepository,
@@ -47,6 +48,7 @@ if TYPE_CHECKING:
         BlockRepositoryProtocol,
         ZombieRepositoryProtocol,
         RatingRepositoryProtocol,
+        RatingArchiveRepositoryProtocol,
         RiddleRepositoryProtocol,
         ImageRepositoryProtocol,
         ReportRepositoryProtocol,
@@ -184,6 +186,9 @@ class PostgreSQLBackend:
         self._blocks: "BlockRepositoryProtocol" = BlockRepository(session)
         self._zombies: "ZombieRepositoryProtocol" = ZombieRepository(session)
         self._ratings: "RatingRepositoryProtocol" = RatingRepository(session)
+        self._rating_archive: "RatingArchiveRepositoryProtocol" = (
+            RatingArchiveRepository(session)
+        )
         self._images: "ImageRepositoryProtocol" = ImageRepository(session)
         self._reports: "ReportRepositoryProtocol" = ReportRepository(session)
         self._promos: "PromoRepositoryProtocol" = PromoRepository(session)
@@ -241,6 +246,11 @@ class PostgreSQLBackend:
     def ratings(self) -> "RatingRepositoryProtocol":
         """Access the Rating repository."""
         return self._ratings
+
+    @property
+    def rating_archive(self) -> "RatingArchiveRepositoryProtocol":
+        """Access the RatingArchive repository."""
+        return self._rating_archive
 
     @property
     def riddles(self) -> "RiddleRepositoryProtocol":

--- a/src/db/postgresql/models.py
+++ b/src/db/postgresql/models.py
@@ -706,6 +706,34 @@ class Rating(Base):
     losses_month_ago: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
 
+class RatingArchive(Base):
+    """Archived daily rating tables - mirrors NDB RatingArchiveModel.
+    One row is written per (kind, date) each time the ratings task runs;
+    historical comparisons (yesterday/week/month ago) are then simple
+    keyed lookups instead of expensive recomputations over the entire
+    stats history."""
+
+    __tablename__ = "rating_archive"
+
+    # Composite primary key: kind ("all", "human" or "manual") + ISO date
+    kind: Mapped[str] = mapped_column(String(16), primary_key=True)
+    # The date that the table was (or would have been) computed,
+    # in ISO format (YYYY-MM-DD)
+    key_date: Mapped[str] = mapped_column(String(10), primary_key=True)
+
+    # The rating table rows as a JSON document
+    table_json: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # The time at which this row was actually written
+    timestamp: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=utcnow
+    )
+
+    @property
+    def key_id(self) -> str:
+        return f"{self.kind}:{self.key_date}"
+
+
 class Riddle(Base):
     """Daily riddles - mirrors NDB RiddleModel."""
 

--- a/src/db/postgresql/repositories.py
+++ b/src/db/postgresql/repositories.py
@@ -47,6 +47,7 @@ from .models import (
     Submission,
     Completion,
     Rating,
+    RatingArchive,
     Riddle,
 )
 
@@ -315,6 +316,21 @@ class UserRepository:
             (u.id, EloDict(u.elo, u.human_elo, u.manual_elo))
             for u in combined[:max_len]
         ]
+
+    def list_top_elo(self, kind: str, limit: int) -> List[str]:
+        """List the ids of the users with the highest current 'old style'
+        (locale-independent) Elo rating of the given kind ('all', 'human'
+        or 'manual'), in descending order. These fields are maintained
+        canonically by the nightly stats run."""
+        if kind == "human":
+            col = User.human_elo
+        elif kind == "manual":
+            col = User.manual_elo
+        else:
+            # Default, kind == 'all'
+            col = User.elo
+        stmt = select(User.id).order_by(desc(col)).limit(limit)
+        return [row[0] for row in self._session.execute(stmt)]
 
     def query(self) -> "PostgreSQLQueryWrapper[User]":
         """Return a query object for users."""
@@ -681,16 +697,21 @@ class StatsRepository:
         return self._session.execute(stmt).scalar_one_or_none()
 
     def newest_before(
-        self, ts: datetime, user_id: str, robot_level: int = 0
+        self, ts: datetime, user_id: Optional[str], robot_level: int = 0
     ) -> Stats:
-        """Get the most recent stats at or before a timestamp."""
+        """Get the most recent stats at or before a timestamp.
+        A user_id of None denotes a robot, further identified by its
+        robot_level, mirroring NDB where robot stats rows have user=None."""
         # Inclusive bound (<=) to match NDB StatsModel.newest_before; the
         # leaderboard false-positive correction relies on the record AT `ts`.
+        user_filter = (
+            Stats.user_id.is_(None) if user_id is None else Stats.user_id == user_id
+        )
         stmt = (
             select(Stats)
             .where(
                 and_(
-                    Stats.user_id == user_id,
+                    user_filter,
                     Stats.robot_level == robot_level,
                     Stats.timestamp <= ts,
                 )
@@ -703,6 +724,19 @@ class StatsRepository:
             return stats
         # No record: return an unpersisted default (NDB does not write here)
         return self._default_stats(user_id, robot_level)
+
+    def newest_before_multi(
+        self, ts: datetime, keys: Sequence[Tuple[Optional[str], int]]
+    ) -> List[Stats]:
+        """Get the most recent stats at or before a timestamp for multiple
+        (user_id, robot_level) keys at once. The result is aligned with the
+        keys sequence; keys without a stored record yield an unpersisted
+        default entity. This mirrors NDB StatsModel.newest_before_multi,
+        which issues the same per-key queries asynchronously."""
+        return [
+            self.newest_before(ts, user_id, robot_level)
+            for user_id, robot_level in keys
+        ]
 
     def last_for_user(self, user_id: str, days: int) -> List[Stats]:
         """Get the newest `days` human (robot_level == 0) stats rows for a
@@ -772,17 +806,32 @@ class StatsRepository:
 
         results = []
         for rank, s in enumerate(self._session.execute(stmt).scalars(), 1):
+            # Extract the fields of the requested kind into the generic
+            # StatsInfo slots, mirroring the NDB _makedict variants in
+            # StatsModel.list_elo / list_human_elo / list_manual_elo
+            if elo_field == "human_elo":
+                games, elo = s.human_games, s.human_elo
+                score, score_against = s.human_score, s.human_score_against
+                wins, losses = s.human_wins, s.human_losses
+            elif elo_field == "manual_elo":
+                games, elo = s.manual_games, s.manual_elo
+                score, score_against = s.manual_score, s.manual_score_against
+                wins, losses = s.manual_wins, s.manual_losses
+            else:
+                games, elo = s.games, s.elo
+                score, score_against = s.score, s.score_against
+                wins, losses = s.wins, s.losses
             results.append(
                 StatsInfo(
                     user=s.user_id,
                     robot_level=s.robot_level,
                     timestamp=s.timestamp,
-                    games=s.games,
-                    elo=s.elo,
-                    score=s.score,
-                    score_against=s.score_against,
-                    wins=s.wins,
-                    losses=s.losses,
+                    games=games,
+                    elo=elo,
+                    score=score,
+                    score_against=score_against,
+                    wins=wins,
+                    losses=losses,
                     rank=rank,
                 )
             )
@@ -1321,6 +1370,36 @@ class RatingRepository:
         stmt = delete(Rating)
         self._session.execute(stmt)
         self._session.flush()
+
+
+class RatingArchiveRepository:
+    """PostgreSQL implementation of RatingArchiveRepositoryProtocol."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def put_archive(self, kind: str, key_date: str, table_json: str) -> None:
+        """Store or overwrite the archived table for a kind and ISO date."""
+        ra = self._session.get(RatingArchive, (kind, key_date))
+        if ra is None:
+            ra = RatingArchive(kind=kind, key_date=key_date, table_json=table_json)
+            self._session.add(ra)
+        else:
+            ra.table_json = table_json
+            ra.timestamp = datetime.now(UTC)
+        self._session.flush()
+
+    def get_archive(self, kind: str, key_date: str) -> Optional[str]:
+        """Fetch the archived table for a kind and ISO date, or None."""
+        ra = self._session.get(RatingArchive, (kind, key_date))
+        return None if ra is None else ra.table_json
+
+    def delete_archive(self, kind: str, key_date: str) -> None:
+        """Delete the archived table for a kind and ISO date, if present."""
+        ra = self._session.get(RatingArchive, (kind, key_date))
+        if ra is not None:
+            self._session.delete(ra)
+            self._session.flush()
 
 
 class RiddleRepository:

--- a/src/db/protocols.py
+++ b/src/db/protocols.py
@@ -818,6 +818,12 @@ class UserRepositoryProtocol(Protocol):
         """List users with similar Elo ratings."""
         ...
 
+    def list_top_elo(self, kind: str, limit: int) -> List[str]:
+        """List the ids of the users with the highest current 'old style'
+        Elo rating of the given kind ('all', 'human' or 'manual'),
+        in descending order."""
+        ...
+
     def query(self) -> QueryProtocol[UserEntityProtocol]:
         """Return a query object for users."""
         ...
@@ -928,9 +934,20 @@ class StatsRepositoryProtocol(Protocol):
         ...
 
     def newest_before(
-        self, ts: datetime, user_id: str, robot_level: int = 0
+        self, ts: datetime, user_id: Optional[str], robot_level: int = 0
     ) -> StatsEntityProtocol:
-        """Get the most recent stats before a timestamp."""
+        """Get the most recent stats at or before a timestamp.
+        A user_id of None denotes a robot, further identified
+        by its robot_level."""
+        ...
+
+    def newest_before_multi(
+        self, ts: datetime, keys: Sequence[Tuple[Optional[str], int]]
+    ) -> Sequence[StatsEntityProtocol]:
+        """Get the most recent stats at or before a timestamp for multiple
+        (user_id, robot_level) keys at once. The result is aligned with
+        the keys sequence; keys without a stored record yield an
+        unpersisted default entity."""
         ...
 
     def last_for_user(self, user_id: str, days: int) -> Sequence[StatsEntityProtocol]:
@@ -1138,6 +1155,24 @@ class RatingRepositoryProtocol(Protocol):
         ...
 
 
+class RatingArchiveRepositoryProtocol(Protocol):
+    """Protocol for archived daily rating table storage.
+    Tables are stored as opaque JSON documents, keyed by
+    (kind, ISO date), and are only ever accessed by key."""
+
+    def put_archive(self, kind: str, key_date: str, table_json: str) -> None:
+        """Store or overwrite the archived table for a kind and ISO date."""
+        ...
+
+    def get_archive(self, kind: str, key_date: str) -> Optional[str]:
+        """Fetch the archived table for a kind and ISO date, or None."""
+        ...
+
+    def delete_archive(self, kind: str, key_date: str) -> None:
+        """Delete the archived table for a kind and ISO date, if present."""
+        ...
+
+
 class RiddleRepositoryProtocol(Protocol):
     """Protocol for Riddle repository operations."""
 
@@ -1333,6 +1368,11 @@ class DatabaseBackendProtocol(Protocol):
     @property
     def ratings(self) -> RatingRepositoryProtocol:
         """Access the Rating repository."""
+        ...
+
+    @property
+    def rating_archive(self) -> RatingArchiveRepositoryProtocol:
+        """Access the RatingArchive repository."""
         ...
 
     @property

--- a/src/skrafldb_ndb.py
+++ b/src/skrafldb_ndb.py
@@ -673,6 +673,23 @@ class UserModel(Model["UserModel"]):
         return cls.query().count()
 
     @classmethod
+    def list_top_elo(cls, kind: str, limit: int) -> List[str]:
+        """Return the ids of the users with the highest current
+        'old style' (locale-independent) Elo rating of the given kind
+        ('all', 'human' or 'manual'), in descending order. These fields
+        are maintained canonically by the nightly stats run."""
+        prop: int
+        if kind == "human":
+            prop = UserModel.human_elo
+        elif kind == "manual":
+            prop = UserModel.manual_elo
+        else:
+            # Default, kind == 'all'
+            prop = UserModel.elo
+        q = cls.query().order(-cast(int, prop))
+        return [k.id() for k in q.fetch(keys_only=True, limit=limit)]
+
+    @classmethod
     def filter_locale(
         cls, q: Query[UserModel], locale: Optional[str]
     ) -> Query[UserModel]:
@@ -2142,6 +2159,39 @@ class StatsModel(Model["StatsModel"]):
         return sm
 
     @classmethod
+    def newest_before_multi(
+        cls, ts: datetime, keys: Sequence[Tuple[Optional[str], int]]
+    ) -> List[StatsModel]:
+        """Returns the newest available stats records at or before the
+        given time, for multiple (user_id, robot_level) keys at once.
+        The result list is aligned with the keys sequence. Queries are
+        issued asynchronously and in parallel, which makes this much
+        faster than repeated newest_before() calls."""
+        futures: List[Future[StatsModel]] = []
+        for user_id, robot_level in keys:
+            k: Optional[Key[UserModel]] = (
+                None if user_id is None else Key(UserModel, user_id)
+            )
+            # Use a common query structure and index for humans and robots
+            q = cls.query(
+                ndb.AND(StatsModel.robot_level == robot_level, StatsModel.user == k)  # type: ignore
+            )
+            q = q.filter(StatsModel.timestamp <= ts).order(
+                -cast(int, StatsModel.timestamp)
+            )
+            futures.append(q.fetch_async(limit=1))
+        Future.wait_all(futures)
+        result: List[StatsModel] = []
+        for (user_id, robot_level), fut in zip(keys, futures):
+            sm = cls.create(user_id, robot_level)
+            sm_list = fut.get_result()
+            if sm_list:
+                # Found: copy the stats
+                sm.copy_from(sm_list[0])
+            result.append(sm)
+        return result
+
+    @classmethod
     def newest_for_user(cls, user_id: str) -> Optional[StatsModel]:
         """Returns the newest available stats record for the user"""
         # This does not work for robots
@@ -2311,6 +2361,58 @@ class RatingModel(Model["RatingModel"]):
     def delete_all(cls) -> None:
         """Delete all ratings records"""
         delete_multi(cls.query().iter(keys_only=True))
+
+
+class RatingArchiveModel(Model["RatingArchiveModel"]):
+    """Stores an archived daily top-ratings table as a JSON text blob.
+    One entity is written per (kind, date) each time the ratings task
+    runs; historical comparisons (yesterday/week/month ago) are then
+    simple keyed lookups instead of expensive recomputations over the
+    entire StatsModel history. Entities are only accessed by key, so
+    no composite indexes are required."""
+
+    # Typically "all", "human" or "manual"
+    kind = Model.Str()
+
+    # The date that the table was (or would have been) computed,
+    # in ISO format (YYYY-MM-DD). The table reflects games finished
+    # before 00:00 UTC on this date.
+    key_date = Model.Str()
+
+    # The rating table rows as a JSON document
+    table_json = Model.Text()
+
+    # The time at which this entity was actually written
+    timestamp = Model.Datetime(auto_now_add=True)
+
+    @staticmethod
+    def _id(kind: str, key_date: str) -> str:
+        """Return the entity id for a (kind, date) combination"""
+        return f"{kind}:{key_date}"
+
+    @classmethod
+    def store(cls, kind: str, key_date: str, table_json: str) -> None:
+        """Store or overwrite the archived table for the given kind and date"""
+        cls(
+            id=cls._id(kind, key_date),
+            kind=kind,
+            key_date=key_date,
+            table_json=table_json,
+        ).put()
+
+    @classmethod
+    def fetch_json(cls, kind: str, key_date: str) -> Optional[str]:
+        """Fetch the archived table for the given kind and date,
+        or None if it does not exist"""
+        k: Key[RatingArchiveModel] = Key(cls, cls._id(kind, key_date))
+        ra = k.get()
+        return None if ra is None else ra.table_json
+
+    @classmethod
+    def delete(cls, kind: str, key_date: str) -> None:
+        """Delete the archived table for the given kind and date, if present"""
+        k: Key[RatingArchiveModel] = Key(cls, cls._id(kind, key_date))
+        k.delete()
 
 
 class ChatModelFuture(Future["ChatModel"]):

--- a/src/skrafldb_pg.py
+++ b/src/skrafldb_pg.py
@@ -643,6 +643,15 @@ class UserModel:
         ]
 
     @classmethod
+    def list_top_elo(cls, kind: str, limit: int) -> List[str]:
+        """Return the ids of the users with the highest current
+        'old style' (locale-independent) Elo rating of the given kind
+        ('all', 'human' or 'manual'), in descending order. These fields
+        are maintained canonically by the nightly stats run."""
+        db = _get_db()
+        return db.users.list_top_elo(kind, limit)
+
+    @classmethod
     def delete_related_entities(cls, user_id: str) -> None:
         """Delete entities related to a user."""
         if not user_id:
@@ -1588,7 +1597,9 @@ class StatsModel:
         cls._NB_CACHE_STATS["misses"] += 1
         sm = cls.create(user_id, robot_level)
 
-        if ts and user_id:
+        if ts:
+            # Note that a user_id of None denotes a robot, further
+            # identified by its robot_level, mirroring the NDB backend
             db = _get_db()
             entity = db.stats.newest_before(ts, user_id, robot_level)
             if entity is not None:
@@ -1600,6 +1611,23 @@ class StatsModel:
             cache[key][ts] = sm
 
         return sm
+
+    @classmethod
+    def newest_before_multi(
+        cls, ts: datetime, keys: Sequence[Tuple[Optional[str], int]]
+    ) -> List[StatsModel]:
+        """Returns the newest available stats records at or before the
+        given time, for multiple (user_id, robot_level) keys at once.
+        The result list is aligned with the keys sequence."""
+        db = _get_db()
+        entities = db.stats.newest_before_multi(ts, keys)
+        result: List[StatsModel] = []
+        for (user_id, robot_level), entity in zip(keys, entities):
+            sm = cls.create(user_id, robot_level)
+            if entity is not None:
+                sm.copy_from(cls._from_entity(entity))
+            result.append(sm)
+        return result
 
     @classmethod
     def newest_for_user(cls, user_id: str) -> Optional[StatsModel]:
@@ -1777,6 +1805,35 @@ class RatingModel:
     def delete_all(cls) -> None:
         db = _get_db()
         db.ratings.delete_all()
+
+
+# ---------------------------------------------------------------------------
+# RatingArchiveModel
+# ---------------------------------------------------------------------------
+
+class RatingArchiveModel:
+    """PostgreSQL facade for RatingArchiveModel. Stores an archived
+    daily top-ratings table as a JSON text blob, keyed by (kind, date),
+    mirroring the NDB backend."""
+
+    @classmethod
+    def store(cls, kind: str, key_date: str, table_json: str) -> None:
+        """Store or overwrite the archived table for the given kind and date"""
+        db = _get_db()
+        db.rating_archive.put_archive(kind, key_date, table_json)
+
+    @classmethod
+    def fetch_json(cls, kind: str, key_date: str) -> Optional[str]:
+        """Fetch the archived table for the given kind and date,
+        or None if it does not exist"""
+        db = _get_db()
+        return db.rating_archive.get_archive(kind, key_date)
+
+    @classmethod
+    def delete(cls, kind: str, key_date: str) -> None:
+        """Delete the archived table for the given kind and date, if present"""
+        db = _get_db()
+        db.rating_archive.delete_archive(kind, key_date)
 
 
 # ---------------------------------------------------------------------------

--- a/src/skraflstats.py
+++ b/src/skraflstats.py
@@ -9,36 +9,50 @@
     International Public License (CC-BY-NC 4.0) applies to this software.
     For further information, see https://github.com/mideind/Netskrafl
 
-    This module implements two endpoints, /stats/run and /stats/ratings.
-    The first one is normally called by the Google Cloud Scheduler at 02:00
-    UTC each night, and the second one at 02:20 UTC. The endpoints cannot
-    be invoked manually via HTTP except when running on a local development
-    server.
+    This module implements three endpoints, /stats/run, /stats/ratings
+    and /stats/ratings_backfill. The first one is normally called by the
+    Google Cloud Scheduler at 02:00 UTC each night, and the second one
+    at 02:20 UTC. The endpoints cannot be invoked manually via HTTP
+    except when running on a local development server.
 
     /stats/run looks at the games played during the preceding day (UTC time)
     and calculates Elo scores and high scores for each game and player.
 
     /stats/ratings creates the top 100 Elo scoreboard, for human-only
-    games and for all games (including human-vs-robot).
+    games and for all games (including human-vs-robot). The tables are
+    computed from current canonical Elo data and then archived by date
+    (in RatingArchiveModel entities), so that historical comparisons
+    (yesterday/week/month ago) are simple keyed lookups instead of
+    expensive recomputations over the entire StatsModel history.
+
+    /stats/ratings_backfill fills in missing archived tables for past
+    dates, one date per invocation, chaining itself via a Cloud Tasks
+    task until done. Kick it off after deployment with:
+
+        gcloud tasks create-app-engine-task --project <project> \\
+            --queue default --location <region> --method GET \\
+            --relative-uri /stats/ratings_backfill
 
 """
 
 from __future__ import annotations
 
-from typing import Dict, Iterable, List, Optional, Tuple, Any, cast
+from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple, Any, cast
 
 import calendar
+import json
 import logging
+import os
 import time
 import gc
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from threading import Thread
 
 from flask import request, Blueprint
 from flask.wrappers import Request
 
-from config import running_local, ResponseType, DEFAULT_ELO
+from config import running_local, ResponseType, DEFAULT_ELO, PROJECT_ID
 from cache import memcache
 from skrafldb import (
     Context,
@@ -48,15 +62,51 @@ from skrafldb import (
     GameModel,
     StatsModel,
     RatingModel,
+    RatingArchiveModel,
     CompletionModel,
     iter_q,
+    put_multi,
     StatsDict,
+    StatsResults,
 )
 from skraflgame import Game
 from skraflelo import ESTABLISHED_MARK, compute_elo
+from autoplayers import AUTOPLAYERS
 
 # Register the Flask blueprint for the stats routes
 stats = stats_blueprint = Blueprint("stats", __name__, url_prefix="/stats")
+
+# The kinds of rating tables that we maintain
+RATING_KINDS = ("all", "human", "manual")
+
+# The length of the rating tables
+MAX_RATINGS = 100
+
+# Number of extra users fetched beyond the table length when computing
+# a current table, to absorb minor ordering drift between the current
+# UserModel Elo values and the newest StatsModel snapshots
+RATINGS_OVERSAMPLE = 50
+
+# How many days further back we search for an archived rating table
+# if the target date is missing (e.g. because the ratings task
+# did not run on that date)
+ARCHIVE_MAX_LOOKBACK = 4
+
+# The default and maximum number of past days that the ratings
+# backfill process looks at; must comfortably cover the month-ago
+# lookback of the ratings task
+BACKFILL_DEFAULT_DAYS = 36
+BACKFILL_MAX_DAYS = 366
+
+# The robot levels that can appear in the 'all' rating table
+ROBOT_LEVELS: List[int] = sorted({apt.level for apl in AUTOPLAYERS.values() for apt in apl})
+
+# The Cloud Tasks queue used for backfill continuation tasks.
+# Every App Engine application has a "default" push queue.
+CLOUD_TASKS_QUEUE = "default"
+CLOUD_TASKS_LOCATION = os.environ.get("CLOUD_TASKS_LOCATION") or (
+    "us-central1" if PROJECT_ID == "netskrafl" else "europe-west1"
+)
 
 
 def monthdelta(date: datetime, delta: int) -> datetime:
@@ -94,20 +144,20 @@ def _write_stats(timestamp: datetime, urecs: Dict[str, StatsModel]) -> None:
             um_list.append(um)
             if len(um_list) >= MAX_USERS_PUT:
                 # At limit: Update the entities that we've gathered so far
-                UserModel.put_multi(um_list)
+                put_multi(um_list)
                 um_list = []
         # Collect the updated StatsModel entities
         sm_list.append(sm)
         if len(sm_list) >= MAX_STATS_PUT:
             # At limit: Update the entities that we've gathered so far
-            StatsModel.put_multi(sm_list)
+            put_multi(sm_list)
             sm_list = []
     # Update the remaining StatsModel entities
     if sm_list:
-        StatsModel.put_multi(sm_list)
+        put_multi(sm_list)
     # Update the remaining UserModel entities
     if um_list:
-        UserModel.put_multi(um_list)
+        put_multi(um_list)
 
 
 def _run_stats(from_time: datetime, to_time: datetime) -> bool:
@@ -327,16 +377,122 @@ def _run_stats(from_time: datetime, to_time: datetime) -> bool:
     return True
 
 
+def _table_to_json(table: StatsResults) -> str:
+    """Serialize a ratings table to JSON for archival"""
+    return json.dumps([dict(d, timestamp=d["timestamp"].isoformat()) for d in table])
+
+
+def _table_from_json(table_json: str) -> StatsResults:
+    """Deserialize a ratings table from its archived JSON form"""
+    rows: List[Dict[str, Any]] = json.loads(table_json)
+    return [
+        cast(StatsDict, dict(d, timestamp=datetime.fromisoformat(d["timestamp"])))
+        for d in rows
+    ]
+
+
+def _fetch_archived_table(kind: str, target: date) -> Dict[str, StatsDict]:
+    """Fetch the archived ratings table of the given kind that is closest
+    to (at or before) the target date, searching up to ARCHIVE_MAX_LOOKBACK
+    days back. Returns a dict keyed by user key (or robot key); empty if
+    no archive is found."""
+    _key = StatsModel.dict_key
+    for back in range(ARCHIVE_MAX_LOOKBACK + 1):
+        d = target - timedelta(days=back)
+        table_json = RatingArchiveModel.fetch_json(kind, d.isoformat())
+        if table_json is not None:
+            return {_key(sd): sd for sd in _table_from_json(table_json)}
+    return {}
+
+
+def _stats_dict(
+    sm: StatsModel, user_id: Optional[str], robot_level: int, kind: str
+) -> StatsDict:
+    """Extract the fields relevant to the given rating kind from a
+    StatsModel entity into a StatsDict"""
+    if kind == "human":
+        games, elo = sm.human_games, sm.human_elo
+        score, score_against = sm.human_score, sm.human_score_against
+        wins, losses = sm.human_wins, sm.human_losses
+    elif kind == "manual":
+        games, elo = sm.manual_games, sm.manual_elo
+        score, score_against = sm.manual_score, sm.manual_score_against
+        wins, losses = sm.manual_wins, sm.manual_losses
+    else:
+        # Default, kind == 'all'
+        games, elo = sm.games, sm.elo
+        score, score_against = sm.score, sm.score_against
+        wins, losses = sm.wins, sm.losses
+    return StatsDict(
+        user=user_id,
+        robot_level=robot_level,
+        timestamp=sm.timestamp,
+        games=games,
+        elo=elo,
+        score=score,
+        score_against=score_against,
+        wins=wins,
+        losses=losses,
+        rank=0,
+    )
+
+
+def _current_ratings_table(
+    kind: str, sticky_keys: Iterable[str], max_len: int = MAX_RATINGS
+) -> StatsResults:
+    """Compute the current top-Elo ratings table of the given kind.
+    Candidates are the users with the highest current Elo ratings (as
+    maintained canonically by the nightly stats run), the robot players
+    (for the 'all' table), and any users present in the most recent
+    archived table (so that entries cannot silently vanish between runs).
+    The stats fields for each candidate come from the candidate's newest
+    StatsModel snapshot, fetched in parallel. Since each candidate maps
+    to exactly one snapshot, this is exact - no false positives can
+    occur, in contrast to the previous global descending-Elo scan over
+    the entire snapshot history."""
+    now = datetime.now(UTC)
+    key_set: Set[str] = set()
+    candidates: List[Tuple[Optional[str], int]] = []
+
+    def add_candidate(user_id: Optional[str], robot_level: int) -> None:
+        k = f"robot-{robot_level}" if user_id is None else user_id
+        if k not in key_set:
+            key_set.add(k)
+            candidates.append((user_id, robot_level))
+
+    for uid in UserModel.list_top_elo(kind, max_len + RATINGS_OVERSAMPLE):
+        add_candidate(uid, 0)
+    if kind == "all":
+        # The 'all' table includes robot players
+        for level in ROBOT_LEVELS:
+            add_candidate(None, level)
+    for k in sticky_keys:
+        add_candidate(*StatsModel.user_id_from_key(k))
+
+    sms = StatsModel.newest_before_multi(now, candidates)
+    table = [
+        _stats_dict(sm, user_id, robot_level, kind)
+        for (user_id, robot_level), sm in zip(candidates, sms)
+    ]
+    # Drop robot entries for levels that have no games recorded
+    table = [d for d in table if d["user"] is not None or d["games"] > 0]
+    # Sort in descending order by Elo, rank and truncate
+    table.sort(key=lambda d: -d["elo"])
+    del table[max_len:]
+    for ix, d in enumerate(table):
+        d["rank"] = ix + 1
+    return table
+
+
 def _create_ratings() -> None:
     """Create the Top 100 ratings tables"""
     logging.info("Starting _create_ratings")
 
-    _key = StatsModel.dict_key
-
     timestamp = datetime.now(UTC)
-    yesterday = timestamp - timedelta(days=1)
-    week_ago = timestamp - timedelta(days=7)
-    month_ago = monthdelta(timestamp, -1)
+    today = timestamp.date()
+    yesterday = today - timedelta(days=1)
+    week_ago = today - timedelta(days=7)
+    month_ago = monthdelta(timestamp, -1).date()
 
     # Collect any stray garbage before we start
     gc.collect()
@@ -352,7 +508,7 @@ def _create_ratings() -> None:
 
         for sm in t:
             # Augment the rating with info about progress
-            key = _key(sm)
+            key = StatsModel.dict_key(sm)
 
             # pylint: disable=cell-var-from-loop
             def _augment(prop: str) -> None:
@@ -375,110 +531,106 @@ def _create_ratings() -> None:
             _augment("score")
             _augment("score_against")
 
-    # All players including robot games
-
-    top100_all = [sm for sm in StatsModel.list_elo(timestamp, 100)]
-    top100_all_yesterday = {_key(sm): sm for sm in StatsModel.list_elo(yesterday, 100)}
-    top100_all_week_ago = {_key(sm): sm for sm in StatsModel.list_elo(week_ago, 100)}
-    top100_all_month_ago = {_key(sm): sm for sm in StatsModel.list_elo(month_ago, 100)}
-
-    # Augment the table for all games
-    _augment_table(
-        top100_all, top100_all_yesterday, top100_all_week_ago, top100_all_month_ago
-    )
-
-    # Human only games
-
-    top100_human = [sm for sm in StatsModel.list_human_elo(timestamp, 100)]
-    top100_human_yesterday = {
-        _key(sm): sm for sm in StatsModel.list_human_elo(yesterday, 100)
-    }
-    top100_human_week_ago = {
-        _key(sm): sm for sm in StatsModel.list_human_elo(week_ago, 100)
-    }
-    top100_human_month_ago = {
-        _key(sm): sm for sm in StatsModel.list_human_elo(month_ago, 100)
-    }
-
-    # Augment the table for human only games
-    _augment_table(
-        top100_human,
-        top100_human_yesterday,
-        top100_human_week_ago,
-        top100_human_month_ago,
-    )
-
-    # Manual (and human only) games
-
-    top100_manual = [sm for sm in StatsModel.list_manual_elo(timestamp, 100)]
-    top100_manual_yesterday = {
-        _key(sm): sm for sm in StatsModel.list_manual_elo(yesterday, 100)
-    }
-    top100_manual_week_ago = {
-        _key(sm): sm for sm in StatsModel.list_manual_elo(week_ago, 100)
-    }
-    top100_manual_month_ago = {
-        _key(sm): sm for sm in StatsModel.list_manual_elo(month_ago, 100)
-    }
-
-    # Augment the table for manual only games
-    _augment_table(
-        top100_manual,
-        top100_manual_yesterday,
-        top100_manual_week_ago,
-        top100_manual_month_ago,
-    )
-
-    logging.info("Deleting top 100 tables")
-    # FIXME: Note that the following call can be deleted after
-    # it has been run once and the indexes have thereby been cleaned up in ndb
-    RatingModel.delete_all()
-    logging.info("Writing top 100 tables to the database")
     t0 = time.time()
-
-    # Write the Top 100 tables to the database
     rlist: List[RatingModel] = []
 
-    for rank in range(0, 100):
+    for kind in RATING_KINDS:
 
-        # All players including robots
-        rm = RatingModel.get_or_create("all", rank + 1)
-        if rank < len(top100_all):
-            rm.assign(top100_all[rank])
-        else:
-            # Sentinel empty records
-            rm.user = None
-            rm.robot_level = -1
-            rm.games = -1
-        rlist.append(rm)
+        # Fetch the archived tables for the historical comparison points
+        t_yesterday = _fetch_archived_table(kind, yesterday)
+        t_week_ago = _fetch_archived_table(kind, week_ago)
+        t_month_ago = _fetch_archived_table(kind, month_ago)
 
-        # Humans only
-        rm = RatingModel.get_or_create("human", rank + 1)
-        if rank < len(top100_human):
-            rm.assign(top100_human[rank])
-        else:
-            # Sentinel empty records
-            rm.user = None
-            rm.robot_level = -1
-            rm.games = -1
-        rlist.append(rm)
+        # Compute the current table; users in the most recent archived
+        # table are included as candidates ("sticky") so that they are
+        # re-evaluated even if their current Elo rating has dropped
+        table = _current_ratings_table(kind, t_yesterday.keys())
 
-        # Manual (and human) only
-        rm = RatingModel.get_or_create("manual", rank + 1)
-        if rank < len(top100_manual):
-            rm.assign(top100_manual[rank])
-        else:
-            # Sentinel empty records
-            rm.user = None
-            rm.robot_level = -1
-            rm.games = -1
-        rlist.append(rm)
+        # Archive today's table (before augmenting it) so that future
+        # runs can use it for their historical comparisons
+        RatingArchiveModel.store(kind, today.isoformat(), _table_to_json(table))
 
+        # Augment the table with data from the historical time points
+        _augment_table(table, t_yesterday, t_week_ago, t_month_ago)
+
+        # Assemble the RatingModel rows for this kind
+        for rank in range(0, MAX_RATINGS):
+            rm = RatingModel.get_or_create(kind, rank + 1)
+            if rank < len(table):
+                rm.assign(table[rank])
+            else:
+                # Sentinel empty records
+                rm.user = None
+                rm.robot_level = -1
+                rm.games = -1
+            rlist.append(rm)
+
+    logging.info("Writing top 100 tables to the database")
     # Put the entire top 100 table in one RPC call
-    RatingModel.put_multi(rlist)
+    put_multi(rlist)
 
     t1 = time.time()
     logging.info("Finishing _create_ratings in {0:.1f} seconds".format(t1 - t0))
+
+
+def _backfill_ratings_for_date(d: date) -> None:
+    """Compute and archive the ratings tables for a past date, as they
+    would have been computed by the ratings task early on that day.
+    This uses the historical StatsModel snapshots via the (slow) legacy
+    descending-Elo scan and is intended for one-time backfill only."""
+    # Stats snapshots are stamped at (UTC) midnight, so any cutoff time
+    # during day d captures exactly the set of snapshots that the
+    # ratings task saw when it ran in the early hours of day d
+    ts = datetime(d.year, d.month, d.day, 12, 0, tzinfo=UTC)
+    listers: List[Tuple[str, Callable[[datetime, int], StatsResults]]] = [
+        ("all", StatsModel.list_elo),
+        ("human", StatsModel.list_human_elo),
+        ("manual", StatsModel.list_manual_elo),
+    ]
+    for kind, lister in listers:
+        if RatingArchiveModel.fetch_json(kind, d.isoformat()) is not None:
+            # Already archived: skip (this makes the backfill idempotent)
+            continue
+        table = lister(ts, MAX_RATINGS)
+        RatingArchiveModel.store(kind, d.isoformat(), _table_to_json(table))
+    # The legacy scan accumulates a large in-memory cache; drop it
+    StatsModel.clear_cache()
+
+
+def _missing_archive_dates(days: int) -> List[date]:
+    """Return the dates within the lookback window that are missing
+    one or more archived rating tables, most recent date first"""
+    today = datetime.now(UTC).date()
+    missing: List[date] = []
+    for delta in range(1, days + 1):
+        d = today - timedelta(days=delta)
+        if any(
+            RatingArchiveModel.fetch_json(kind, d.isoformat()) is None
+            for kind in RATING_KINDS
+        ):
+            missing.append(d)
+    return missing
+
+
+def _enqueue_backfill_task(days: int) -> bool:
+    """Enqueue a Cloud Tasks task to continue the ratings backfill.
+    Returns False if the task could not be enqueued."""
+    try:
+        import google.cloud.tasks_v2 as tasks_v2
+
+        client = tasks_v2.CloudTasksClient()
+        parent = client.queue_path(PROJECT_ID, CLOUD_TASKS_LOCATION, CLOUD_TASKS_QUEUE)
+        task = tasks_v2.Task(
+            app_engine_http_request=tasks_v2.AppEngineHttpRequest(
+                http_method=tasks_v2.HttpMethod.GET,
+                relative_uri=f"/stats/ratings_backfill?days={days}",
+            )
+        )
+        client.create_task(request=tasks_v2.CreateTaskRequest(parent=parent, task=task))
+        return True
+    except Exception as ex:
+        logging.warning(f"Could not enqueue a backfill continuation task: {ex!r}")
+        return False
 
 
 def deferred_stats(from_time: datetime, to_time: datetime, wait: bool) -> bool:
@@ -624,9 +776,12 @@ def ratings(request: Request, *, wait: bool) -> Tuple[str, int]:
 # by the Google Cloud Scheduler
 
 
-@stats.route("/run", methods=["GET", "POST"])
-def stats_run() -> ResponseType:
-    """Start a task to calculate Elo points for games"""
+def _scheduler_wait_mode(task_name: str) -> Optional[bool]:
+    """Check that the current request originates from the Google Cloud
+    Scheduler, a Cloud Tasks queue or a cron job (or from a local
+    development server). Returns None if the request is not authorized;
+    otherwise False if the task should be run asynchronously (Cloud
+    Scheduler requests), or True to run it synchronously."""
     headers: Dict[str, str] = cast(Any, request).headers
     task_queue_name = headers.get("X-AppEngine-QueueName", "")
     task_queue = task_queue_name != ""
@@ -634,42 +789,69 @@ def stats_run() -> ResponseType:
     cron_job = headers.get("X-Appengine-Cron", "") == "true"
     if not any((task_queue, cloud_scheduler, cron_job, running_local)):
         # Only allow bona fide Google Cloud Scheduler or Task Queue requests
-        return "Restricted URL", 403
-    wait = True
+        return None
     if cloud_scheduler:
-        logging.info("Running stats from cloud scheduler")
+        logging.info(f"Running {task_name} from cloud scheduler")
         # Run Cloud Scheduler tasks asynchronously
-        wait = False
-    elif task_queue:
-        logging.info(f"Running stats from queue {task_queue_name}")
+        return False
+    if task_queue:
+        logging.info(f"Running {task_name} from queue {task_queue_name}")
     elif cron_job:
-        logging.info("Running stats from cron job")
+        logging.info(f"Running {task_name} from cron job")
+    return True
+
+
+@stats.route("/run", methods=["GET", "POST"])
+def stats_run() -> ResponseType:
+    """Start a task to calculate Elo points for games"""
+    wait = _scheduler_wait_mode("stats")
+    if wait is None:
+        return "Restricted URL", 403
     return run(request, wait=wait)
 
 
 @stats.route("/ratings", methods=["GET", "POST"])
 def stats_ratings() -> ResponseType:
     """Start a task to calculate top Elo rankings"""
-    headers: Dict[str, str] = cast(Any, request).headers
-    task_queue_name = headers.get("X-AppEngine-QueueName", "")
-    task_queue = task_queue_name != ""
-    cloud_scheduler = request.environ.get("HTTP_X_CLOUDSCHEDULER", "") == "true"
-    cron_job = headers.get("X-Appengine-Cron", "") == "true"
-    if not any((task_queue, cloud_scheduler, cron_job, running_local)):
-        # Only allow bona fide Google Cloud Scheduler or Task Queue requests
+    wait = _scheduler_wait_mode("ratings")
+    if wait is None:
         return "Restricted URL", 403
-    wait = True
-    if cloud_scheduler:
-        logging.info("Running ratings from cloud scheduler")
-        # Run Cloud Scheduler tasks asynchronously
-        wait = False
-    elif task_queue:
-        logging.info(f"Running ratings from queue {task_queue_name}")
-    elif cron_job:
-        logging.info("Running ratings from cron job")
     result, status = ratings(request, wait=wait)
     if status == 200:
         # New ratings: ensure that old ones are deleted from cache
         memcache.delete("all", namespace="rating")
         memcache.delete("human", namespace="rating")
+        memcache.delete("manual", namespace="rating")
     return result, status
+
+
+@stats.route("/ratings_backfill", methods=["GET", "POST"])
+def stats_ratings_backfill() -> ResponseType:
+    """Backfill missing archived ratings tables, one date per invocation,
+    chaining via a Cloud Tasks task until no dates are missing"""
+    if _scheduler_wait_mode("ratings_backfill") is None:
+        return "Restricted URL", 403
+    try:
+        days = int(request.args.get("days", str(BACKFILL_DEFAULT_DAYS)))
+    except ValueError:
+        return "Invalid days parameter", 400
+    days = max(1, min(days, BACKFILL_MAX_DAYS))
+    missing = _missing_archive_dates(days)
+    if not missing:
+        logging.info("Ratings backfill is complete; no dates are missing")
+        return "Backfill complete", 200
+    d = missing[0]
+    t0 = time.time()
+    _backfill_ratings_for_date(d)
+    t1 = time.time()
+    remaining = len(missing) - 1
+    logging.info(
+        f"Backfilled ratings for {d.isoformat()} in {t1 - t0:.1f} seconds; "
+        f"{remaining} date(s) remaining"
+    )
+    if remaining > 0 and not _enqueue_backfill_task(days):
+        logging.warning(
+            "Backfill continuation could not be enqueued; "
+            "re-invoke /stats/ratings_backfill to continue"
+        )
+    return f"Backfilled {d.isoformat()}; {remaining} date(s) remaining", 200

--- a/src/skraflstats.py
+++ b/src/skraflstats.py
@@ -620,10 +620,19 @@ def _enqueue_backfill_task(days: int) -> bool:
 
         client = tasks_v2.CloudTasksClient()
         parent = client.queue_path(PROJECT_ID, CLOUD_TASKS_LOCATION, CLOUD_TASKS_QUEUE)
+        # Pin the continuation task to the service/version that is
+        # currently executing; without explicit routing, App Engine
+        # would send it to the default (promoted) version, breaking
+        # backfill chains that run on a not-yet-promoted deployment
+        routing = tasks_v2.AppEngineRouting(
+            service=os.environ.get("GAE_SERVICE", "default"),
+            version=os.environ.get("GAE_VERSION", ""),
+        )
         task = tasks_v2.Task(
             app_engine_http_request=tasks_v2.AppEngineHttpRequest(
                 http_method=tasks_v2.HttpMethod.GET,
                 relative_uri=f"/stats/ratings_backfill?days={days}",
+                app_engine_routing=routing,
             )
         )
         client.create_task(request=tasks_v2.CreateTaskRequest(parent=parent, task=task))

--- a/tests/db/test_rating_archive_repository.py
+++ b/tests/db/test_rating_archive_repository.py
@@ -1,0 +1,264 @@
+"""
+Tests for the RatingArchive repository and the batch/leaderboard helper
+operations added for the optimized ratings process:
+
+    * rating_archive.put_archive / get_archive / delete_archive
+    * stats.newest_before_multi (including robot keys)
+    * users.list_top_elo
+
+These tests run against any backend implementing the DatabaseBackendProtocol.
+Use the --backend option to select which backend(s) to test.
+
+Note: against the NDB backend, these tests write to the explo-dev
+Datastore; all entities that are created are deleted again on teardown.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from typing import Iterator, List, Optional, Tuple, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.db.protocols import DatabaseBackendProtocol
+
+UTC = timezone.utc
+
+# A robot level that is not used by any real autoplayer configuration
+TEST_ROBOT_LEVEL = 971
+
+
+def _delete_robot_stats(backend: "DatabaseBackendProtocol", robot_level: int) -> None:
+    """Delete robot stats rows created by these tests. There is no
+    protocol-level deletion method for robot stats, so this reaches
+    into the backend implementations."""
+    from src.db.ndb.backend import NDBBackend
+
+    if isinstance(backend, NDBBackend):
+        import skrafldb_ndb
+
+        delete_keys = list(
+            skrafldb_ndb.StatsModel.query(
+                skrafldb_ndb.ndb.AND(
+                    skrafldb_ndb.StatsModel.robot_level == robot_level,
+                    skrafldb_ndb.StatsModel.user == None,  # noqa: E711
+                )
+            ).iter(keys_only=True)
+        )
+        skrafldb_ndb.delete_multi(delete_keys)
+    else:
+        from sqlalchemy import delete
+        from src.db.postgresql.models import Stats
+        from src.db.postgresql.backend import PostgreSQLBackend
+
+        assert isinstance(backend, PostgreSQLBackend)
+        session = backend._session  # noqa: SLF001 - test-only cleanup
+        session.execute(
+            delete(Stats).where(
+                Stats.user_id.is_(None), Stats.robot_level == robot_level
+            )
+        )
+        session.flush()
+
+
+class TestRatingArchive:
+    """Test the RatingArchive repository operations."""
+
+    KIND = "test-kind"
+    DATE = "2020-01-15"
+
+    @pytest.fixture(autouse=True)
+    def cleanup_archive(
+        self, backend: "DatabaseBackendProtocol"
+    ) -> Iterator[None]:
+        """Delete the test archive rows after each test."""
+        yield
+        backend.rating_archive.delete_archive(self.KIND, self.DATE)
+
+    def test_get_missing_returns_none(
+        self, backend: "DatabaseBackendProtocol"
+    ) -> None:
+        """Fetching a nonexistent archive returns None."""
+        assert backend.rating_archive.get_archive(self.KIND, "1999-12-31") is None
+
+    def test_put_get_roundtrip(self, backend: "DatabaseBackendProtocol") -> None:
+        """An archived table can be stored and fetched unchanged."""
+        table = json.dumps([{"user": "u1", "elo": 1500, "rank": 1}])
+        backend.rating_archive.put_archive(self.KIND, self.DATE, table)
+        assert backend.rating_archive.get_archive(self.KIND, self.DATE) == table
+
+    def test_put_overwrites(self, backend: "DatabaseBackendProtocol") -> None:
+        """Storing again for the same (kind, date) overwrites the table."""
+        backend.rating_archive.put_archive(self.KIND, self.DATE, "[1]")
+        backend.rating_archive.put_archive(self.KIND, self.DATE, "[2]")
+        assert backend.rating_archive.get_archive(self.KIND, self.DATE) == "[2]"
+
+    def test_keys_are_distinct(self, backend: "DatabaseBackendProtocol") -> None:
+        """Tables are keyed by both kind and date."""
+        backend.rating_archive.put_archive(self.KIND, self.DATE, "[1]")
+        assert backend.rating_archive.get_archive(self.KIND, "2020-01-16") is None
+        assert backend.rating_archive.get_archive("other-kind", self.DATE) is None
+
+    def test_delete(self, backend: "DatabaseBackendProtocol") -> None:
+        """A deleted archive is no longer fetchable."""
+        backend.rating_archive.put_archive(self.KIND, self.DATE, "[1]")
+        backend.rating_archive.delete_archive(self.KIND, self.DATE)
+        assert backend.rating_archive.get_archive(self.KIND, self.DATE) is None
+        # Deleting a nonexistent archive is a no-op
+        backend.rating_archive.delete_archive(self.KIND, self.DATE)
+
+
+class TestNewestBeforeMulti:
+    """Test the batch newest_before_multi operation."""
+
+    USER_1 = "nbm-test-user-1"
+    USER_2 = "nbm-test-user-2"
+
+    @pytest.fixture(autouse=True)
+    def setup_and_cleanup(
+        self, backend: "DatabaseBackendProtocol"
+    ) -> Iterator[None]:
+        """Create test users, per-user stats and robot stats;
+        delete them all afterwards."""
+        for i, user_id in enumerate((self.USER_1, self.USER_2)):
+            if backend.users.get_by_id(user_id) is None:
+                backend.users.create(
+                    user_id=user_id,
+                    account=f"test:nbm{i}",
+                    email=None,
+                    nickname=f"NbmUser{i}",
+                    locale="is_IS",
+                )
+            backend.stats.create(user_id=user_id)
+        # A robot stats row
+        backend.stats.create(user_id=None, robot_level=TEST_ROBOT_LEVEL)
+        yield
+        backend.stats.delete_for_user(self.USER_1)
+        backend.stats.delete_for_user(self.USER_2)
+        _delete_robot_stats(backend, TEST_ROBOT_LEVEL)
+        backend.users.delete(self.USER_1)
+        backend.users.delete(self.USER_2)
+
+    def test_results_aligned_with_keys(
+        self, backend: "DatabaseBackendProtocol"
+    ) -> None:
+        """Results come back in the same order as the requested keys,
+        including robot keys and keys without stored records."""
+        future = datetime.now(UTC) + timedelta(hours=1)
+        keys: List[Tuple[Optional[str], int]] = [
+            (self.USER_2, 0),
+            (None, TEST_ROBOT_LEVEL),
+            ("nbm-test-nonexistent", 0),
+            (self.USER_1, 0),
+        ]
+        results = backend.stats.newest_before_multi(future, keys)
+        assert len(results) == len(keys)
+        assert results[0].user_id == self.USER_2
+        assert results[1].user_id is None
+        assert results[1].robot_level == TEST_ROBOT_LEVEL
+        # Nonexistent key yields an unpersisted default record
+        assert results[2].user_id == "nbm-test-nonexistent"
+        assert results[2].elo == 1200
+        assert results[2].games == 0
+        assert results[3].user_id == self.USER_1
+
+    def test_matches_newest_before(
+        self, backend: "DatabaseBackendProtocol"
+    ) -> None:
+        """The batch operation returns the same data as individual
+        newest_before calls, for both humans and robots."""
+        future = datetime.now(UTC) + timedelta(hours=1)
+        keys: List[Tuple[Optional[str], int]] = [
+            (self.USER_1, 0),
+            (None, TEST_ROBOT_LEVEL),
+        ]
+        multi = backend.stats.newest_before_multi(future, keys)
+        for (user_id, robot_level), batched in zip(keys, multi):
+            single = backend.stats.newest_before(future, user_id, robot_level)
+            assert batched.user_id == single.user_id
+            assert batched.robot_level == single.robot_level
+            assert batched.elo == single.elo
+            assert batched.games == single.games
+
+    def test_respects_timestamp_bound(
+        self, backend: "DatabaseBackendProtocol"
+    ) -> None:
+        """Records newer than the cutoff timestamp are not returned."""
+        past = datetime.now(UTC) - timedelta(days=365)
+        results = backend.stats.newest_before_multi(past, [(self.USER_1, 0)])
+        # The only stored record is from now, i.e. after the cutoff,
+        # so a default record is returned
+        assert results[0].elo == 1200
+        assert results[0].games == 0
+
+
+class TestListTopElo:
+    """Test the users.list_top_elo operation."""
+
+    # Elo values high enough to outrank any real data in a shared
+    # test datastore
+    USERS = [
+        ("lte-test-user-1", "test:lte1", 99999, 99997, 99998),
+        ("lte-test-user-2", "test:lte2", 99997, 99999, 99997),
+        ("lte-test-user-3", "test:lte3", 99998, 99998, 99999),
+    ]
+
+    @pytest.fixture(autouse=True)
+    def setup_and_cleanup(
+        self, backend: "DatabaseBackendProtocol"
+    ) -> Iterator[None]:
+        """Create test users with distinct Elo ratings;
+        delete them afterwards."""
+        for user_id, account, elo, human_elo, manual_elo in self.USERS:
+            if backend.users.get_by_id(user_id) is None:
+                backend.users.create(
+                    user_id=user_id,
+                    account=account,
+                    email=None,
+                    nickname=user_id,
+                    locale="is_IS",
+                )
+            user = backend.users.get_by_id(user_id)
+            assert user is not None
+            backend.users.update(
+                user, elo=elo, human_elo=human_elo, manual_elo=manual_elo
+            )
+        yield
+        for user_id, _, _, _, _ in self.USERS:
+            backend.users.delete(user_id)
+
+    def _ranking(self, backend: "DatabaseBackendProtocol", kind: str) -> List[str]:
+        """Return our test users in the order they appear in the top list."""
+        top = backend.users.list_top_elo(kind, 10)
+        ours = {u[0] for u in self.USERS}
+        return [uid for uid in top if uid in ours]
+
+    def test_list_top_elo_all(self, backend: "DatabaseBackendProtocol") -> None:
+        """Users are returned in descending order of 'all' Elo."""
+        assert self._ranking(backend, "all") == [
+            "lte-test-user-1",
+            "lte-test-user-3",
+            "lte-test-user-2",
+        ]
+
+    def test_list_top_elo_human(self, backend: "DatabaseBackendProtocol") -> None:
+        """Users are returned in descending order of human Elo."""
+        assert self._ranking(backend, "human") == [
+            "lte-test-user-2",
+            "lte-test-user-3",
+            "lte-test-user-1",
+        ]
+
+    def test_list_top_elo_manual(self, backend: "DatabaseBackendProtocol") -> None:
+        """Users are returned in descending order of manual Elo."""
+        assert self._ranking(backend, "manual") == [
+            "lte-test-user-3",
+            "lte-test-user-1",
+            "lte-test-user-2",
+        ]
+
+    def test_limit_is_respected(self, backend: "DatabaseBackendProtocol") -> None:
+        """No more than `limit` ids are returned."""
+        assert len(backend.users.list_top_elo("all", 2)) == 2


### PR DESCRIPTION
## Summary

The nightly `/stats/ratings` task previously derived every top-100 table (3 kinds × 4 time points) by scanning the **entire StatsModel history** (3.5M entities on netskrafl) in descending Elo order, followed by thousands of serial per-candidate correction queries. This took ~11 minutes on netskrafl, degraded as data grew, and produced false positives that sometimes truncated the top-100 lists below 100 entries.

This PR replaces the algorithm:

- **Current tables are computed exactly from canonical current data.** Candidates come from the indexed `UserModel` Elo fields (plus robot players for the 'all' table, plus "sticky" members of the most recent archived table so entries cannot silently vanish). Stats for each candidate come from their newest `StatsModel` snapshot, fetched in parallel via the new `StatsModel.newest_before_multi()`. One candidate maps to exactly one snapshot, so **false positives are structurally impossible**.
- **Each night's finished tables are archived by date** as JSON blobs in a new `RatingArchiveModel` kind (PG: `rating_archive` table), accessed by key only — no new composite indexes, no index direction changes. Yesterday/week/month comparisons become 9 keyed lookups (with a 4-day fallback window for skipped nights) instead of 9 full recomputations.
- **A new `/stats/ratings_backfill` endpoint** fills in missing archive dates using the retained legacy scan, one date per invocation, self-chaining via a Cloud Tasks task on the default App Engine queue until done. Idempotent and retry-safe. Continuation tasks are pinned via `AppEngineRouting` to the service/version that is executing the chain, so a backfill can run entirely on a deployed-but-not-yet-promoted version.

Both backends implement **identical schemas and algorithms** for the new facade APIs (`UserModel.list_top_elo`, `StatsModel.newest_before_multi`, `RatingArchiveModel`), preserving NDB/PG comparability for the migration project.

### Parity fixes found along the way

- PG `StatsRepository._list_by_elo` returned 'all'-kind stats fields for the human/manual leaderboards; it now extracts kind-specific fields, mirroring the NDB `_makedict` variants.
- PG `StatsModel.newest_before` never queried robot stats (`user_id is None`); it now mirrors NDB, and the protocol signature allows `Optional[str]`.
- `skraflstats` now uses the module-level `put_multi()`, which exists in both backends (the classmethod variant it previously called was NDB-only, so the stats job would have crashed on PG).
- `/stats/ratings` now also invalidates the `manual` rating memcache entry (previously only `all` and `human`).
- Removed the `RatingModel.delete_all()` call per its FIXME note (upsert-in-place produces the same state with half the writes).

## Verification

- `pyright src/`: 0 errors
- `tests/db/`: 308 passed on both backends, plus 24 new parity tests (archive CRUD, batch snapshot lookups incl. robots, top-Elo listing), all with explicit explo-dev cleanup
- `test/`: 49 passed
- **PG end-to-end** (seeded local DB): backfill → ratings run → verified ordering, kind-specific stats, robot inclusion, yesterday/week augmentation values, month-ago zero default, second-run stability
- **NDB against real explo-dev data**: read-only new-vs-legacy comparison showed **zero Elo mismatches**; only differences were in the arbitrary 1200-Elo tie region and orphan test entities that the legacy scan wrongly includes. New path 0.5s vs legacy 7.5s per table; a full write run took 13.4s. On netskrafl (25× more data) the expected speedup is ~30–50× (11 min → well under 30 s).

## Backfill and transition plan

The archives are **not** a cache over a legacy fallback: the nightly job never invokes the old scan. Where an archive date is missing, the yesterday/week/month delta columns simply show 0 (rendered as "no change / new entry") and converge automatically as archives accumulate — yesterday-deltas after 2 nights, week-ago after 7 days, month-ago after ~31 days. The backfill exists solely to make the deltas exact immediately, and its useful scope is bounded: the job never reads archives older than one calendar month + 4-day lookback, hence `BACKFILL_DEFAULT_DAYS = 36`. There is no meaningful backfill beyond that.

The recommended rollout runs the backfill on a **deployed-but-not-yet-promoted version**, so the heavy legacy scans stay off the serving instances and the promoted cutover is atomic. Archives are shared Datastore state, so everything the unpromoted version backfills is immediately usable once promoted. Per project:

1. **Deploy without promoting:**
   ```
   gcloud app deploy --project <p> --no-promote --version <new-version>
   ```
   The old promoted version keeps running the nightly jobs unchanged in the meantime.
2. **Kick off the backfill, targeted at the new version:**
   ```
   # netskrafl
   gcloud tasks create-app-engine-task --project netskrafl --queue default \
       --location us-central1 --method GET --relative-uri /stats/ratings_backfill \
       --routing version:<new-version>

   # explo-dev / explo-live (if backfilled at all — see follow-ups)
   gcloud tasks create-app-engine-task --project explo-dev --queue default \
       --location europe-west1 --method GET --relative-uri /stats/ratings_backfill \
       --routing version:<new-version>
   ```
   Continuation tasks inherit the routing automatically (pinned to `GAE_SERVICE`/`GAE_VERSION` of the executing instance), so the whole chain stays on the unpromoted version.
3. **Chain size and duration:** up to 36 tasks per project (one per missing date), strictly sequential, self-terminating. Estimated per-task / total: explo-dev ~15–25 s / ~10–15 min; explo-live ~30–60 s / ~20–40 min; netskrafl ~2–3 min / ~1.5–2 h. Each task is idempotent (already-archived dates are skipped), so Cloud Tasks retries or a repeated kick-off simply resume where the chain left off. Progress is visible in the logs (`Backfilled ratings for <date> ...; N date(s) remaining`).
4. **Promote once the chain reports 0 dates remaining.** The new code's first nightly run then produces fully exact tables. On netskrafl, re-pin the `update_online_status` Cloud Scheduler job to the new version as usual.
5. **Nothing else changes:** the `RatingModel` output tables, the `/rating` API, memcache usage and the web UI are untouched — only the producer side is new. The legacy scan (`StatsModel._list_by`) is retained solely for the backfill and can be deleted once all projects are backfilled.
6. **Rollback:** before promotion, simply don't promote; after promotion, revert to the previous version and the old nightly job resumes as before. Archives are additive and harmless to leave in place either way.

### Post-merge follow-ups (not in this PR)

- Consider dropping the `/stats/ratings` cron job (and skipping the backfill) on the explo projects entirely: the only consumer of `RatingModel` is the old-style locale-ignorant `/rating` API (`logic.rating()`), while Explo's per-locale top-100 (`/rating_locale`) is generated live from the real-time `EloModel` with 5-minute memcaching and needs no batch job. Verify in explo-front that no fielded client version still calls `/rating` before removing the cron entry.
- `tests/db/test_stats_repository.py` (pre-existing) leaves orphan users/stats in explo-dev; these show up in leaderboard tails and should get cleanup fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
