### PR TITLE
Make /stats/ratings a no-op outside Netskrafl

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,27 @@ multiple languages through separate DAWG files and tile sets.
 - A project is underway to migrate from Google Cloud to a containerized deployment,
   probably on Digital Ocean, with PostgreSQL replacing Google NDB
 
+### Scheduled jobs (GAE)
+
+- `cron.yaml` defines three jobs: `/stats/run` (03:00), `/stats/ratings` (03:45)
+  and `/connect/update` ("Online users", every 2 minutes). It is deployed on
+  explo-dev and explo-live, where all three run via legacy App Engine cron.
+- **Netskrafl's deployed cron config is older** and contains only the two `/stats`
+  jobs; there, `/connect/update` is instead triggered by a manually created,
+  **version-pinned** Cloud Scheduler job `update_online_status` (us-central1),
+  which must be re-pinned after every deploy/promotion (see `deploy-netskrafl.sh`).
+  This split is a historical accident (the "Online users" cron entry was added in
+  2024 but cron.yaml was never redeployed to netskrafl). Possible future cleanup:
+  deploy `cron.yaml` to netskrafl and delete the Cloud Scheduler job, removing the
+  re-pin chore. Low priority, as the container migration replaces GAE cron with
+  supercronic anyway.
+- `/stats/ratings` (and `/stats/ratings_backfill`) are no-ops outside the
+  netskrafl project (guarded by the `NETSKRAFL` config flag): the old-style,
+  locale-ignorant rating tables are only displayed on Netskrafl, while Explo
+  serves per-locale ratings live from `EloModel` via `/rating_locale`.
+  `/stats/run` remains essential in all projects (profile stats, 30-day Elo
+  history, `UserModel` Elo fallback fields).
+
 ## Coding Standards
 
 - The #!/usr/bin/env python3 shebang is not required and should be omitted.

--- a/src/skraflstats.py
+++ b/src/skraflstats.py
@@ -52,7 +52,7 @@ from threading import Thread
 from flask import request, Blueprint
 from flask.wrappers import Request
 
-from config import running_local, ResponseType, DEFAULT_ELO, PROJECT_ID
+from config import running_local, ResponseType, DEFAULT_ELO, NETSKRAFL, PROJECT_ID
 from cache import memcache
 from skrafldb import (
     Context,
@@ -825,6 +825,12 @@ def stats_ratings() -> ResponseType:
     wait = _scheduler_wait_mode("ratings")
     if wait is None:
         return "Restricted URL", 403
+    if not NETSKRAFL:
+        # The old-style, locale-ignorant rating tables are only
+        # maintained (and displayed) on Netskrafl; Explo uses live
+        # per-locale EloModel ratings via /rating_locale instead
+        logging.info("Skipping ratings task; not applicable in this project")
+        return "Not applicable in this project", 200
     result, status = ratings(request, wait=wait)
     if status == 200:
         # New ratings: ensure that old ones are deleted from cache
@@ -840,6 +846,10 @@ def stats_ratings_backfill() -> ResponseType:
     chaining via a Cloud Tasks task until no dates are missing"""
     if _scheduler_wait_mode("ratings_backfill") is None:
         return "Restricted URL", 403
+    if not NETSKRAFL:
+        # See comment in stats_ratings() above
+        logging.info("Skipping ratings backfill; not applicable in this project")
+        return "Not applicable in this project", 200
     try:
         days = int(request.args.get("days", str(BACKFILL_DEFAULT_DAYS)))
     except ValueError:


### PR DESCRIPTION
## Summary

The nightly `/stats/ratings` job produces the old-style, locale-ignorant `RatingModel` top-100 tables, whose only consumer is the `/rating` API used by the Netskrafl web UI. On the Explo projects the job has been running all along (via the shared `cron.yaml`), mixing all locales into tables that no client reads — Explo's per-locale top-100 comes from live `EloModel` data via `/rating_locale` with 5-minute memcaching.

This PR guards `/stats/ratings` and `/stats/ratings_backfill` with the existing `NETSKRAFL` config flag: outside the netskrafl project they log a line and return **200 "Not applicable in this project"** without doing any work. Returning 200 (not 4xx/5xx) keeps the cron scheduler recording successful runs with no retries, so the shared `cron.yaml` needs no per-project fork.

`/stats/run` is untouched — it remains essential everywhere (profile statistics and the 30-day Elo history come from its `StatsModel` snapshots, and it maintains the `UserModel` Elo fallback fields).

## Verification

- `pyright src/skraflstats.py`: 0 errors
- No behavior change on netskrafl (`NETSKRAFL == True` short-circuits nothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)