### PR TITLE
Remove obsolete Cloud Scheduler re-pin step after cron consolidation

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -32,11 +32,15 @@ traffic increase. Never delete or stop old versions unless the user asks.
 
 ## Target configuration
 
-| Target      | app.yaml              | credentials                                 | project     | prefix | scheduler update |
-|-------------|-----------------------|---------------------------------------------|-------------|--------|------------------|
-| netskrafl   | `app-netskrafl.yaml`  | `credentials/netskrafl/service-account.json`| `netskrafl` | `n`    | yes (`update_online_status`, location `us-central1`) |
-| explo-live  | `app-explo-live.yaml` | `credentials/explo-live/service-account.json`| `explo-live`| `e`    | none |
-| explo-dev   | `app-explo.yaml`      | `credentials/explo-dev/service-account.json`| `explo-dev` | `e`    | none |
+| Target      | app.yaml              | credentials                                 | project     | prefix |
+|-------------|-----------------------|---------------------------------------------|-------------|--------|
+| netskrafl   | `app-netskrafl.yaml`  | `credentials/netskrafl/service-account.json`| `netskrafl` | `n`    |
+| explo-live  | `app-explo-live.yaml` | `credentials/explo-live/service-account.json`| `explo-live`| `e`    |
+| explo-dev   | `app-explo.yaml`      | `credentials/explo-dev/service-account.json`| `explo-dev` | `e`    |
+
+All recurring jobs (`/stats/run`, `/stats/ratings`, `/connect/update`) run via the
+shared `cron.yaml`, deployed to all three projects; cron always targets the
+promoted version, so no per-version scheduler updates are needed on any target.
 
 The default service name is `default`.
 
@@ -129,22 +133,9 @@ For each stage in **10% → 25% → 50% → 100%**:
    Use `severity>=WARNING` (not just `ERROR`) so significant warnings are
    surfaced too. A rise in warnings or non-200 statuses on the new version is a
    signal even without hard errors. If anything looks abnormal, **stop and
-   recommend rollback** (step 6) rather than advancing.
+   recommend rollback** (see Rollback below) rather than advancing.
 
-### 5. Post-promote (netskrafl only)
-
-Once the new version is at 100% and healthy, repoint the online-status scheduler
-job (it is pinned to a specific version):
-
-```bash
-gcloud scheduler jobs update app-engine update_online_status \
-  --version=<VERSION> --project=netskrafl --location=us-central1
-```
-
-(`Clear-Redis` is yearly and does not need updating. explo-live/explo-dev have no
-such job.)
-
-### 6. Finish
+### 5. Finish
 
 - **Do not delete or stop old versions** — leave them for rollback. Mention to
   the user that older versions remain and can be cleaned up later.
@@ -157,10 +148,10 @@ To instantly route all traffic back to the previous version:
 ```bash
 gcloud app services set-traffic default --splits=<CURRENT>=1 \
   --split-by=cookie --project=<project> --quiet
-# netskrafl: also repoint the scheduler back
-gcloud scheduler jobs update app-engine update_online_status \
-  --version=<CURRENT> --project=netskrafl --location=us-central1
 ```
+
+Cron jobs follow the promoted version automatically; no scheduler changes are
+needed on rollback.
 
 ## Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,17 +138,15 @@ multiple languages through separate DAWG files and tile sets.
 ### Scheduled jobs (GAE)
 
 - `cron.yaml` defines three jobs: `/stats/run` (03:00), `/stats/ratings` (03:45)
-  and `/connect/update` ("Online users", every 2 minutes). It is deployed on
-  explo-dev and explo-live, where all three run via legacy App Engine cron.
-- **Netskrafl's deployed cron config is older** and contains only the two `/stats`
-  jobs; there, `/connect/update` is instead triggered by a manually created,
-  **version-pinned** Cloud Scheduler job `update_online_status` (us-central1),
-  which must be re-pinned after every deploy/promotion (see `deploy-netskrafl.sh`).
-  This split is a historical accident (the "Online users" cron entry was added in
-  2024 but cron.yaml was never redeployed to netskrafl). Possible future cleanup:
-  deploy `cron.yaml` to netskrafl and delete the Cloud Scheduler job, removing the
-  re-pin chore. Low priority, as the container migration replaces GAE cron with
-  supercronic anyway.
+  and `/connect/update` ("Online users", every 2 minutes). It is deployed on all
+  three projects (netskrafl, explo-dev, explo-live), where the jobs run via
+  legacy App Engine cron, always targeting the promoted version. No per-version
+  scheduler updates are needed after deploys. (Consolidated 2026-08-07; before
+  that, netskrafl triggered `/connect/update` via a version-pinned Cloud
+  Scheduler job that had to be re-pinned after every promotion.)
+- The only remaining Cloud Scheduler job is `Clear-Redis` on netskrafl (yearly);
+  explo-dev also has a daily `clear-cache` job. The container migration will
+  replace GAE cron with supercronic.
 - `/stats/ratings` (and `/stats/ratings_backfill`) are no-ops outside the
   netskrafl project (guarded by the `NETSKRAFL` config flag): the old-style,
   locale-ignorant rating tables are only displayed on Netskrafl, while Explo

--- a/deploy-netskrafl.sh
+++ b/deploy-netskrafl.sh
@@ -25,7 +25,7 @@ function indexes
 function cron
 {
     echo "Cron update starting"
-    echo "*** Currently disabled ***"
+    gcloud app deploy --project=netskrafl cron.yaml
     echo "Cron update completed"
 }
 
@@ -39,19 +39,6 @@ function default # $1=version
     grunt make
     gcloud app deploy --no-cache --version=$1 --no-promote --project=netskrafl app-netskrafl.yaml
     echo "Default module deployment completed"
-
-    # Prompt to update Cloud Scheduler job
-    read -p "Update Cloud Scheduler job 'update_online_status' to use version '$1'? (y/n) " -n 1 -r
-    echo
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-        echo "Updating Cloud Scheduler job..."
-        gcloud scheduler jobs update app-engine update_online_status \
-            --version=$1 \
-            --project=netskrafl
-        echo "Cloud Scheduler job updated successfully"
-    else
-        echo "Skipped Cloud Scheduler update. REMEMBER to update manually if needed."
-    fi
 }
 
 case $cmd in


### PR DESCRIPTION
## Summary

The netskrafl `/connect/update` presence job has been consolidated onto legacy App Engine cron, matching the explo projects (infrastructure change performed 2026-08-07):

- `cron.yaml` — which includes the every-2-minutes **Online users** entry added in 2024 but never previously deployed to netskrafl — is now deployed on all three projects. Verified: the cron-driven job fires every 2 minutes on netskrafl with 200s, gap-free.
- The manually created, **version-pinned** `update_online_status` Cloud Scheduler job on netskrafl has been deleted (after a paused-and-verified transition). Cron always targets the promoted version, so the re-pin-after-every-promotion chore is gone.

This PR cleans up the now-obsolete references:

- `deploy-netskrafl.sh`: drop the interactive scheduler re-pin prompt; re-enable the `cron` subcommand (deploys `cron.yaml` to netskrafl).
- `.claude/skills/deploy/SKILL.md`: remove the post-promote scheduler step and the rollback re-pin; note that cron follows the promoted version on all targets.
- `CLAUDE.md`: update the "Scheduled jobs (GAE)" section to describe the consolidated state.

No application code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)