### PR TITLE
Serve session-auth user lookups from the entity cache

### DIFF
--- a/src/basics.py
+++ b/src/basics.py
@@ -315,9 +315,12 @@ def session_user() -> Optional[User]:
         # Old-style session: nested user id dictionary
         userid = u.get("id", "")
 
-    # First, try to resolve a user from the session cookie
+    # First, try to resolve a user from the session cookie.
+    # This runs on every authenticated request, so the entity cache is
+    # allowed to serve the user record (a Datastore round trip here was
+    # measured at ~99% of the total cost of light API calls).
     if userid:
-        user = User.load_if_exists(userid)
+        user = User.load_if_exists(userid, cached=True)
         if user is not None:
             return user
 
@@ -330,7 +333,7 @@ def session_user() -> Optional[User]:
         if claims:
             userid = claims.get("sub", "")
             if userid:
-                return User.load_if_exists(userid)
+                return User.load_if_exists(userid, cached=True)
 
     return None
 

--- a/src/skrafldb_ndb.py
+++ b/src/skrafldb_ndb.py
@@ -576,6 +576,17 @@ class UserModel(Model["UserModel"]):
         return cls.get_by_id(user_id, use_cache=False, use_global_cache=False)
 
     @classmethod
+    def fetch_cached(cls, user_id: str) -> Optional[UserModel]:
+        """Fetch a user entity by id, allowing the NDB context cache and
+        the Redis global cache to serve the result. Used on the hot
+        session-authentication path, where a Datastore round trip per
+        request is prohibitively expensive. The global cache is
+        invalidated by put(), so in-application updates remain coherent;
+        out-of-band writers (local utility scripts) must be followed by
+        a /cacheflush, as documented in CLAUDE.md."""
+        return cls.get_by_id(user_id, use_cache=True, use_global_cache=True)
+
+    @classmethod
     def fetch_account(cls, account: str) -> Optional[UserModel]:
         """Attempt to fetch a user by OAuth2 account id,
         eventually prefixed by the authentication provider"""

--- a/src/skrafldb_pg.py
+++ b/src/skrafldb_pg.py
@@ -755,6 +755,15 @@ class UserModel:
         return cls._from_entity(entity)
 
     @classmethod
+    def fetch_cached(cls, user_id: str) -> Optional[UserModel]:
+        """Fetch a user entity by id. On the PostgreSQL backend this is
+        identical to fetch(): there is no entity cache to bypass, and an
+        in-VPC SQL primary-key fetch is already cheap. The distinct name
+        exists for parity with the NDB facade, where the session-auth
+        path uses the cached variant."""
+        return cls.fetch(user_id)
+
+    @classmethod
     def fetch_account(cls, account: str) -> Optional[UserModel]:
         """Fetch a user by OAuth2 account id."""
         if not account:

--- a/src/skrafluser.py
+++ b/src/skrafluser.py
@@ -1097,12 +1097,17 @@ class User:
         return True
 
     @classmethod
-    def load_if_exists(cls, uid: Optional[str]) -> Optional[User]:
-        """Load a user by id if she exists, otherwise return None"""
+    def load_if_exists(
+        cls, uid: Optional[str], *, cached: bool = False
+    ) -> Optional[User]:
+        """Load a user by id if she exists, otherwise return None.
+        With cached=True, the entity cache may serve the result
+        (stale until the entity's next put()); this is appropriate
+        for the hot session-authentication path."""
         if not uid:
             return None
         with User._lock:
-            um = UserModel.fetch(uid)
+            um = UserModel.fetch_cached(uid) if cached else UserModel.fetch(uid)
             if um is None:
                 return None
             u = cls(uid=uid)


### PR DESCRIPTION
## Summary

`session_user()` → `User.load_if_exists()` → `UserModel.fetch()` runs on **every authenticated request**, and `fetch()` bypasses both the NDB context cache and the Redis global cache — a full Datastore round trip on the hottest line in the codebase.

Measured on `/wordcheck` (the most frequent API call):

| Stage | Cost |
|---|---|
| 16-word DAWG check (the route's actual work) | 0.12 ms |
| `UserModel.fetch` (uncached, Datastore RTT) | **~81 ms** |
| Same fetch via the entity cache | ~0.15 ms |

- New `UserModel.fetch_cached()` allows the context + global cache; used **only** by the session-cookie and bearer-token auth lookups in `basics.session_user()`. All other `fetch()` callers unchanged.
- Coherency: the Redis global cache is invalidated by `put()`, so in-app updates propagate immediately across instances. The only staleness source is out-of-band writers (local utility scripts), for which `/cacheflush` is already the documented follow-up.
- PG facade gets an identical-behavior `fetch_cached()` for symbol parity (no entity cache to bypass there).
- Benefits GAE production today as well as the DO container.

## Test plan

- `test/` suite: 50 passed (exercises session auth on every request).
- `tests/db/test_user_repository.py --backend=both`: 18 passed, 5 skipped.
- pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)