### PR TITLE
Send move notifications via Firebase off the request thread

### DIFF
--- a/src/firebase.py
+++ b/src/firebase.py
@@ -97,6 +97,29 @@ def init_firebase_app():
             )
 
 
+def send_message_in_background(
+    message: Optional[Mapping[str, Any]], *args: str
+) -> None:
+    """Fire-and-forget variant of send_message(), for hot request paths:
+    the Firebase HTTP round trip (~40-100 ms) runs on a daemon thread so
+    the request does not wait for it. Errors are logged by send_message()
+    itself; the firebase_admin SDK is thread-safe."""
+    threading.Thread(
+        target=send_message, args=(message, *args), daemon=True
+    ).start()
+
+
+def push_to_user_in_background(
+    user_id: str, message: PushMessageDict, data: Optional[PushDataDict]
+) -> None:
+    """Fire-and-forget variant of push_to_user(), for hot request paths:
+    the per-session FCM pushes involve multiple Firebase round trips that
+    the request should not wait for. Errors are logged by push_to_user()."""
+    threading.Thread(
+        target=push_to_user, args=(user_id, message, data), daemon=True
+    ).start()
+
+
 def send_message(message: Optional[Mapping[str, Any]], *args: str) -> bool:
     """Updates data in Firebase. If a message object is provided, then it updates
     the data at the given location (whose path is built as a concatenation

--- a/src/logic.py
+++ b/src/logic.py
@@ -672,9 +672,11 @@ def process_move(
             f"user/{opponent}/move": move_dict,
         }
         # Push a Firebase notification message to the opponent,
-        # in the correct language for each client session
+        # in the correct language for each client session.
+        # Fire-and-forget: the per-session FCM round trips should not
+        # delay the reply to the player who submitted the move.
         opp_nick = game.player_nickname(1 - opponent_index)
-        firebase.push_to_user(
+        firebase.push_to_user_in_background(
             opponent,
             {
                 "title": lambda locale: localize_push_message("title", locale),
@@ -695,7 +697,11 @@ def process_move(
         msg_dict[f"user/{player}/move"] = move_dict
 
     if msg_dict:
-        firebase.send_message(msg_dict)
+        # Fire-and-forget: the Firebase PATCH (~40-100 ms round trip)
+        # notifies the other party and other client sessions; the player
+        # who submitted the move gets the new state in the HTTP response
+        # below and should not wait for it
+        firebase.send_message_in_background(msg_dict)
 
     # Return a state update to the client (board, rack, score, movelist, etc.)
     return jsonify(game.client_state(1 - opponent_index))


### PR DESCRIPTION
## Summary

Part of the /submitmove latency review (measured 640 ms for a robot-game move on DO staging). The accounting:

| Stage | Est. cost |
|---|---|
| Session auth (uncached at measurement time) | ~80 ms — fixed separately in #156 |
| Game.load (Datastore fetch, transactional necessity) | ~40–90 ms |
| Robot move generation (Python, 1 vCPU) | ~80–600 ms (rack-dependent; a blank is the worst case) |
| game.store (Datastore put) | ~40–90 ms |
| **firebase.send_message (synchronous)** | **~40–60 ms — this PR** |

The mover gets the new game state in the HTTP response; the Firebase PATCH and (for human opponents) per-session FCM pushes only serve the *other* party's clients — so they now run fire-and-forget on daemon threads. Errors remain logged by the underlying functions; firebase_admin is thread-safe. Other `send_message` call sites unchanged.

Not addressed here, noted for later: robot movegen belongs in the GoSkrafl sidecar (needs a vocabulary parameter in its /moves API for the robot dictionary subsets); the Datastore load/store RTTs shrink to ~1–5 ms with the PostgreSQL migration.

## Test plan

- `test/` suite: 50 passed (plays moves through /submitmove throughout)
- `test/test_concurrency.py`: 4 passed
- pyright clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)